### PR TITLE
C++23; std::generator; docs; +semver:minor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,15 +3,12 @@
     "C_Cpp.default.cppStandard": "c++23",
     "C_Cpp.default.cStandard": "c11",
     "C_Cpp.autoAddFileAssociations": false,
-    "cmake.cmakePath": "C:\\Users\\patrik.maraczek\\DevTools\\CMake-3.30.9\\bin\\cmake.exe",
-    // "cmake.generator": "Ninja", // This is duplicite and overrides presets
     "cmake.parallelJobs": 0,
     "cmake.configureOnOpen": true,
     "makefile.configureOnOpen": false,
     "[cpp]": {
         "editor.defaultFormatter": "xaver.clang-format"
     },
-    //"clang-format.executable": "c:\\LLVM\\bin\\clang-format.exe",
     "clang-format.assumeFilename": ".clang-format",
     "c-cpp-flylint.cppcheck.inconclusive": true,
     "c-cpp-flylint.flawfinder.enable": false,
@@ -33,7 +30,6 @@
         "misc-implicitlyVirtual"
     ],
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
-    "cmake.buildDirectory": "${workspaceFolder}/build/${buildType}",
     "cmake.useCMakePresets": "always",
     "cmake.buildBeforeRun": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     //* C++
-    "C_Cpp.default.cppStandard": "c++20",
+    "C_Cpp.default.cppStandard": "c++23",
     "C_Cpp.default.cStandard": "c11",
     "C_Cpp.autoAddFileAssociations": false,
     "cmake.cmakePath": "C:\\Users\\patrik.maraczek\\DevTools\\CMake-3.30.9\\bin\\cmake.exe",

--- a/CMakeUserPresetsExample.json
+++ b/CMakeUserPresetsExample.json
@@ -2,7 +2,7 @@
     "version": 3,
     "vendor": {
         "watchlist.dev/requirements/1.0": {
-            "cmake": ">= 3.21",
+            "cmake": "3.30.9",
             "generator": "Ninja",
             "visualStudioBuildTools": "2026",
             "msvcToolset": "14.51.36231",
@@ -17,6 +17,7 @@
             "displayName": "Default Config",
             "description": "Default build configuration using VS 2026 Build Tools, Windows SDK, and Ninja paths.",
             "inherits": "base-default",
+            "cmakeExecutable": "C:/Users/patrik.maraczek/DevTools/CMake-3.30.9/bin/cmake.exe",
             "environment": {
                 "VCToolsInstallDir": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231/",
                 "VCINSTALLDIR": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/",

--- a/CMakeUserPresetsExample.json
+++ b/CMakeUserPresetsExample.json
@@ -4,8 +4,8 @@
         "watchlist.dev/requirements/1.0": {
             "cmake": ">= 3.21",
             "generator": "Ninja",
-            "visualStudioBuildTools": "2022",
-            "msvcToolset": "14.41.34120",
+            "visualStudioBuildTools": "2026",
+            "msvcToolset": "14.51.36231",
             "windowsSdk": "10.0.26100.0",
             "tracy": "0.13.1",
             "gitVersion": "6.5.1"
@@ -15,30 +15,30 @@
         {
             "name": "default",
             "displayName": "Default Config",
-            "description": "Default build configuration using your local MSVC, Windows SDK, and Ninja paths.",
+            "description": "Default build configuration using VS 2026 Build Tools, Windows SDK, and Ninja paths.",
             "inherits": "base-default",
             "environment": {
-                "VCToolsInstallDir": "C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/Tools/MSVC/14.41.34120/",
-                "VCINSTALLDIR": "C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/",
+                "VCToolsInstallDir": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231/",
+                "VCINSTALLDIR": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/",
                 "WindowsSdkDir": "C:/Program Files (x86)/Windows Kits/10/",
                 "WindowsSDKVersion": "10.0.26100.0/",
-                "PATH": "C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/Tools/MSVC/14.41.34120/bin/HostX64/x64;C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja;C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64;$penv{PATH}",
-                "INCLUDE": "C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/Tools/MSVC/14.41.34120/include;C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/Auxiliary/VS/include;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/ucrt;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/um;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/shared;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/winrt;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/cppwinrt",
-                "LIB": "C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/Tools/MSVC/14.41.34120/lib/x64;C:/Program Files (x86)/Windows Kits/10/lib/10.0.26100.0/ucrt/x64;C:/Program Files (x86)/Windows Kits/10/lib/10.0.26100.0/um/x64",
-                "LIBPATH": "C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/Tools/MSVC/14.41.34120/lib/x64;C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/Tools/MSVC/14.41.34120/lib/x86/store/references;C:/Program Files (x86)/Windows Kits/10/UnionMetadata/10.0.26100.0;C:/Program Files (x86)/Windows Kits/10/References/10.0.26100.0;C:/Windows/Microsoft.NET/Framework64/v4.0.30319"
+                "PATH": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231/bin/HostX64/x64;C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja;C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64;$penv{PATH}",
+                "INCLUDE": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231/include;C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Auxiliary/VS/include;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/ucrt;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/um;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/shared;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/winrt;C:/Program Files (x86)/Windows Kits/10/include/10.0.26100.0/cppwinrt",
+                "LIB": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231/lib/x64;C:/Program Files (x86)/Windows Kits/10/lib/10.0.26100.0/ucrt/x64;C:/Program Files (x86)/Windows Kits/10/lib/10.0.26100.0/um/x64",
+                "LIBPATH": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231/lib/x64;C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231/lib/x86/store/references;C:/Program Files (x86)/Windows Kits/10/UnionMetadata/10.0.26100.0;C:/Program Files (x86)/Windows Kits/10/References/10.0.26100.0;C:/Windows/Microsoft.NET/Framework64/v4.0.30319"
             },
             "cacheVariables": {
-                "CMAKE_MAKE_PROGRAM": "C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe",
-                "CMAKE_C_COMPILER": "C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/Tools/MSVC/14.41.34120/bin/HostX64/x64/cl.exe",
-                "CMAKE_CXX_COMPILER": "C:/Users/patrik.maraczek/DevTools/Microsoft Visual Studio/BuildTools/VC/Tools/MSVC/14.41.34120/bin/HostX64/x64/cl.exe",
+                "CMAKE_MAKE_PROGRAM": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe",
+                "CMAKE_C_COMPILER": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231/bin/HostX64/x64/cl.exe",
+                "CMAKE_CXX_COMPILER": "C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231/bin/HostX64/x64/cl.exe",
                 "CMAKE_RC_COMPILER": "C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/rc.exe",
                 "CMAKE_MT": "C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/mt.exe"
             }
         },
         {
             "name": "with-profiling",
-            "displayName": "With Tracy Profiling",
-            "description": "Enable Tracy profiling using your local MSVC, Windows SDK, and Ninja paths.",
+            "displayName": "Tracy Profiling",
+            "description": "Enable Tracy profiling using VS 2026 Build Tools, Windows SDK, and Ninja paths.",
             "inherits": [
                 "base-with-profiling",
                 "default"

--- a/cmake/CompilerSettings.cmake
+++ b/cmake/CompilerSettings.cmake
@@ -1,6 +1,26 @@
 # Set C++ standard
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# include(CheckCXXSourceCompiles)
+# check_cxx_source_compiles("
+# #include <generator>
+
+# std::generator<int> values()
+# {
+#   co_yield 1;
+# }
+
+# int main()
+# {
+#   auto generated = values();
+#   return *generated.begin();
+# }
+# " WATCHLIST_HAS_STD_GENERATOR)
+
+# if(NOT WATCHLIST_HAS_STD_GENERATOR)
+#   message(FATAL_ERROR "This project requires C++23 std::generator support. Update the compiler/STL toolchain or use one that provides <generator>.")
+# endif()
 
 # ccache
 find_program(CCACHE_FOUND ccache)

--- a/cmake/CompilerSettings.cmake
+++ b/cmake/CompilerSettings.cmake
@@ -2,26 +2,6 @@
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# include(CheckCXXSourceCompiles)
-# check_cxx_source_compiles("
-# #include <generator>
-
-# std::generator<int> values()
-# {
-#   co_yield 1;
-# }
-
-# int main()
-# {
-#   auto generated = values();
-#   return *generated.begin();
-# }
-# " WATCHLIST_HAS_STD_GENERATOR)
-
-# if(NOT WATCHLIST_HAS_STD_GENERATOR)
-#   message(FATAL_ERROR "This project requires C++23 std::generator support. Update the compiler/STL toolchain or use one that provides <generator>.")
-# endif()
-
 # ccache
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)

--- a/docs/DevelopmentEnvironment.md
+++ b/docs/DevelopmentEnvironment.md
@@ -14,16 +14,19 @@ If `CMakeUserPresets.json` is missing, CMake stops with a development environmen
 
 | Tool | Version | Notes |
 | --- | --- | --- |
-| CMake | 3.21 or newer; last known working version 3.30.9 | Required by `CMakeLists.txt`. |
+| CMake | 3.30.9 | Selected by `cmakeExecutable` in the user presets. |
 | Ninja | bundled with Visual Studio Build Tools | Used by the CMake presets. |
-| Visual Studio Build Tools | 2022 | Required for the documented Windows MSVC build. |
-| Visual Studio Developer Command Prompt | 2022 v17.11.5 | Last known working command prompt version. |
-| MSVC compiler | 19.41.34123 for x64 | Last known working compiler version. |
-| MSVC toolset path | 14.41.34120 | Used in the preset path example. |
+| Visual Studio Build Tools | 2026 | Required for the documented Windows MSVC build. |
+| Visual Studio Developer Command Prompt | 2026 | Recommended when launching VS Code outside of the preset environment. |
+| MSVC compiler | 19.51.36243 for x64 | Required for C++23 standard library support used by the concurrency examples. |
+| MSVC toolset path | 14.51.36231 | Used in the preset path example. |
 | Windows SDK | 10.0.26100.0 | Used in the preset path example. |
 | Tracy | 0.13.1 | Vendored under `libs/tracy`. |
 | .NET SDK | compatible with GitVersion.Tool 6.5.1 | Required to install GitVersion as a .NET global tool. |
 | GitVersion | 6.5.1 | Required for automatic version metadata. |
+
+The project requests C++23. `EventLoopGenerator` uses `std::generator`, so older MSVC/STL installs that
+accept C++23 mode but do not ship the generator header are not sufficient.
 
 ## CMake Presets
 
@@ -84,6 +87,22 @@ Install Visual Studio Build Tools from:
 <https://aka.ms/vs/stable/vs_BuildTools.exe>
 
 During installation, include the C++ build tools, MSVC compiler, Windows SDK, CMake tools, and Ninja.
+
+The preset examples currently assume this installation layout:
+
+```text
+C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools
+C:/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231
+```
+
+Although Visual Studio Build Tools also bundles CMake, the user presets select:
+
+```text
+C:/Users/patrik.maraczek/DevTools/CMake-3.30.9/bin/cmake.exe
+```
+
+This keeps the build on the tested CMake version while still using the VS 2026
+MSVC compiler, bundled Ninja, and Windows SDK tools.
 
 To use the MSVC compiler from VS Code, start VS Code from "Developer Command Prompt for Visual Studio". You also need an appropriate Visual Studio license for the MSVC compiler.
 

--- a/src/Utils/Concurrency/EventLoopGenerator.hpp
+++ b/src/Utils/Concurrency/EventLoopGenerator.hpp
@@ -45,10 +45,10 @@
 #include <mutex>
 #include <condition_variable>
 #include <chrono>
+#include <generator>
 #include <memory>
 #include <ranges>
 #include <optional>
-#include <coroutine>
 #include <format>
 
 #include "src/Utils/Logger/Logger.hpp"
@@ -71,115 +71,6 @@ public:
         int id;
         std::string name;
         std::function<void()> action;
-    };
-    
-    // C++23 generator for processing events
-    template<typename T>
-    class generator {
-    public:
-        struct promise_type {
-            T current_value;
-            
-            generator get_return_object() {
-                return generator{std::coroutine_handle<promise_type>::from_promise(*this)};
-            }
-            
-            std::suspend_always initial_suspend() noexcept { return {}; }
-            std::suspend_always final_suspend() noexcept { return {}; }
-            
-            std::suspend_always yield_value(T value) {
-                current_value = std::move(value);
-                return {};
-            }
-            
-            void return_void() {}
-            
-            void unhandled_exception() {
-                std::terminate();
-            }
-        };
-        
-        generator(std::coroutine_handle<promise_type> handle) : handle_(handle) {}
-        
-        ~generator() {
-            if (handle_) handle_.destroy();
-        }
-        
-        // Non-copyable
-        generator(const generator&) = delete;
-        generator& operator=(const generator&) = delete;
-        
-        // Movable
-        generator(generator&& other) noexcept : handle_(other.handle_) {
-            other.handle_ = {};
-        }
-        
-        generator& operator=(generator&& other) noexcept {
-            if (this != &other) {
-                if (handle_) handle_.destroy();
-                handle_ = other.handle_;
-                other.handle_ = {};
-            }
-            return *this;
-        }
-        
-        class iterator {
-        public:
-            using iterator_category = std::input_iterator_tag;
-            using value_type = T;
-            using difference_type = std::ptrdiff_t;
-            using pointer = T*;
-            using reference = T&;
-            
-            iterator() = default;
-            explicit iterator(std::coroutine_handle<promise_type> handle) : handle_(handle) {
-                if (handle_ && !handle_.done()) {
-                    handle_.resume();
-                }
-            }
-            
-            reference operator*() const {
-                return handle_.promise().current_value;
-            }
-            
-            iterator& operator++() {
-                if (handle_ && !handle_.done()) {
-                    handle_.resume();
-                }
-                return *this;
-            }
-            
-            iterator operator++(int) {
-                iterator tmp = *this;
-                ++(*this);
-                return tmp;
-            }
-            
-            bool operator==(const iterator& other) const {
-                if (handle_.done() && (!other.handle_ || other.handle_.done())) {
-                    return true;
-                }
-                return handle_.address() == other.handle_.address();
-            }
-            
-            bool operator!=(const iterator& other) const {
-                return !(*this == other);
-            }
-            
-        private:
-            std::coroutine_handle<promise_type> handle_{};
-        };
-        
-        iterator begin() {
-            return iterator{handle_};
-        }
-        
-        iterator end() {
-            return {};
-        }
-        
-    private:
-        std::coroutine_handle<promise_type> handle_;
     };
     
     EventLoopGenerator() : running_(true) {
@@ -218,7 +109,7 @@ public:
     }
     
     // Generate events based on a pattern
-    generator<Event> event_generator(int count, const std::string& pattern_name, 
+    std::generator<Event> event_generator(int count, const std::string& pattern_name, 
                                     std::function<void(int)> pattern_action) {
         PROFILE_MESSAGE("[TRACY][ELOOP_GEN] Generator coroutine starts yielding events lazily");
         for (int i = 0; i < count; ++i) {
@@ -242,7 +133,7 @@ public:
     }
     
     // Process events from the generator
-    void process_event_sequence(generator<Event>&& gen) {
+    void process_event_sequence(std::generator<Event>&& gen) {
         PROFILE_FUNCTION;
         PROFILE_MESSAGE("[TRACY][ELOOP_GEN] Start producer thread: pull generator values and schedule them");
         std::thread([this, gen = std::move(gen)]() mutable {

--- a/src/Utils/Concurrency/EventLoopGenerator.hpp
+++ b/src/Utils/Concurrency/EventLoopGenerator.hpp
@@ -1,38 +1,34 @@
 /**
  * @file EventLoopGenerator.hpp
- * @brief Implementation of an event loop using C++23 generators
+ * @brief Implementation of an event loop using C++23 std::generator.
  * 
- * This file provides a generator-based event loop implementation that allows for:
- * - Creating streams of events that can be processed sequentially
- * - Lazy evaluation of event sequences
- * - Compositional event processing pipelines
+ * This file provides a generator-based event loop example that:
+ * - Creates a lazy stream of events with std::generator<Event>
+ * - Pulls generated events from a producer thread
+ * - Schedules pulled events onto a worker-thread event queue
  * 
- * The implementation leverages C++23 generators to create an elegant and
- * efficient event processing system. Key components include:
+ * The implementation relies on the C++23 standard library generator instead of
+ * maintaining custom coroutine promise/iterator machinery in this project.
+ * Key components include:
  * 
  * - EventLoopGenerator: Main class that processes event streams
  * - Event: Represents a discrete occurrence to be processed
- * - Generator adapters: Functions that transform, filter, or combine event streams
+ * - event_generator(): Lazily yields a sequence of generated events
+ * - process_event_sequence(): Consumes a generator and schedules its events
  * 
  * Usage example:
  * ```cpp
  * EventLoopGenerator loop;
  * 
- * // Create an event generator
- * auto timeEvents = loop.createTimerEvents(100ms);
- * 
- * // Process events from the generator
- * loop.process(timeEvents, [](const Event& event) {
- *     LOG_INFO(std::format("Processing event at {}", event.timestamp));
+ * auto events = loop.event_generator(5, "Sequential Task", [](int i) {
+ *     LOG_INFO(std::format("Executing sequential task step {}", i));
  * });
  * 
- * // Run the event loop
- * loop.run();
+ * loop.process_event_sequence(std::move(events));
  * ```
  * 
- * The generator approach allows for elegant composition of event sources and
- * provides a pull-based model for event processing that can be more efficient
- * for certain types of applications.
+ * std::generator is single-pass and lazy: events are produced only as the
+ * producer thread iterates the sequence.
  */
 
 #pragma once
@@ -57,11 +53,12 @@
 namespace Concurrency {
 
 /**
- * @brief A C++23 generator-based event loop implementation.
+ * @brief A C++23 std::generator-based event loop implementation.
  * 
  * This example demonstrates:
  * - Using std::generator to create an event processing pipeline
- * - Asynchronous task scheduling with generators
+ * - Lazy event production on a producer thread
+ * - Asynchronous task scheduling on a worker thread
  * - Event-driven programming patterns
  */
 class EventLoopGenerator {


### PR DESCRIPTION
## Summary

- Replace the custom coroutine generator in `EventLoopGenerator` with C++23 `std::generator<Event>`.
- Raise the project C++ standard from C++20 to C++23.
- Update the documented Windows toolchain/preset example to VS 2026 Build Tools with MSVC 14.51 and CMake 3.30.9.
- Clean up VS Code CMake settings so CMake Tools relies on presets instead of duplicating the CMake executable/build directory in `.vscode/settings.json`.

## Details

`EventLoopGenerator` now includes `<generator>` and returns/accepts `std::generator<Event>` directly. The old nested `generator<T>` implementation and its custom `promise_type`/iterator machinery were removed.

The generator remains lazy and single-pass: `event_generator()` yields events as the producer thread iterates, and `process_event_sequence()` schedules each yielded event onto the worker-thread queue.

The development environment docs now call out the C++23 `<generator>` requirement and the tested MSVC 19.51 / toolset 14.51 setup. `CMakeUserPresetsExample.json` points at the VS 2026 Build Tools paths, bundled Ninja, Windows SDK tools, and the explicitly selected CMake 3.30.9 executable.

## Verification

- `cmake --fresh --preset default`
- `cmake --build --preset default --target ConcurrencyExamples`

